### PR TITLE
Fix Null Reference in Anime and Manga commands

### DIFF
--- a/Skuld.Bot/Modules/Weeb.cs
+++ b/Skuld.Bot/Modules/Weeb.cs
@@ -74,6 +74,7 @@ namespace Skuld.Bot.Commands
                 if (response == null)
                 {
                     await sentmessage.DeleteAsync().ConfigureAwait(false);
+                    return;
                 }
 
                 var selection = Convert.ToInt32(response.Content);
@@ -144,6 +145,7 @@ namespace Skuld.Bot.Commands
                 if (response == null)
                 {
                     await sentmessage.DeleteAsync().ConfigureAwait(false);
+                    return;
                 }
 
                 var selection = Convert.ToInt32(response.Content);


### PR DESCRIPTION
If the user doesn't reply to the pagination, `response` is null, causing a null reference exception due to not breaking out of the command flow. This commit adds the missing return statements.